### PR TITLE
Update to Latest version

### DIFF
--- a/lib/tagtical/taggable/core.rb
+++ b/lib/tagtical/taggable/core.rb
@@ -386,7 +386,7 @@ module Tagtical::Taggable
           tag_lists = tag_list_cache_on(tag_type) || {}
           tag_lists.each do |expanded_tag_types, tag_list|
             next unless expanded_tag_types.include?(tag_type)
-            tags += tag_type.klass.find_or_build_tags(tag_list.uniq).keys
+            tags += tag_type.klass.find_or_build_tags(tag_list.uniq, self.tag_types).keys
           end
         end
         tags.each do |tag|

--- a/lib/tagtical/taggable/core.rb
+++ b/lib/tagtical/taggable/core.rb
@@ -51,7 +51,7 @@ module Tagtical::Taggable
           Tagtical::Tag.define_scope_for_type(tag_type)
 
           define_tag_scope(tag_type)
-          
+
           define_has_tag_scope(tag_type)
 
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
@@ -109,12 +109,13 @@ module Tagtical::Taggable
         #   taggable_model.tags(true, :scope => :current) <-- reloads the tags association and appends scope for only current type.
       def define_tag_scope(tag_type)
         if tag_type.has_many_name==:tags
-          define_method("tags_with_finder_type_options") do |*args|
-            bool = args.shift if [true, false].include?(args.first)
-            tags = tags_without_finder_type_options(bool)
-            args.empty? ? tags : tags_with_type_scoping(tag_type, *args)
-          end
-          alias_method_chain :tags, :finder_type_options
+          self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def tags(*args)
+              reload_assoc = args.shift if [true, false].include?(args.first)
+              result = super(reload_assoc)
+              args.empty? ? result : tags_with_type_scoping(tag_type, *args)
+            end
+          RUBY
         else # handle the Tagtical::Tag subclasses
           define_method(tag_type.scope_name) do |*args|
             if tags.loaded?
@@ -419,7 +420,7 @@ module Tagtical::Taggable
       def tags_with_type_scoping(tag_type, *args)
         tags.scoped.merge(tag_type.scoping(*args))
       end
-      
+
       # Lets say tag class A inherits from B and B has a tag with value "foo". If we tag A with value "foo",
       # we want B to have only one instance of "foo" and that tag should be an instance of A (a subclass of B).
       def update_tagging_with_inherited_tag!(tagging, tags, tag_value_lookup)

--- a/lib/tagtical/taggable/core.rb
+++ b/lib/tagtical/taggable/core.rb
@@ -109,13 +109,11 @@ module Tagtical::Taggable
         #   taggable_model.tags(true, :scope => :current) <-- reloads the tags association and appends scope for only current type.
       def define_tag_scope(tag_type)
         if tag_type.has_many_name==:tags
-          self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def tags(*args)
-              reload_assoc = args.shift if [true, false].include?(args.first)
-              result = super(reload_assoc)
-              args.empty? ? result : tags_with_type_scoping(tag_type, *args)
-            end
-          RUBY
+          define_method :tags do |*args|
+            reload_assoc = args.shift if [true, false].include?(args.first)
+            result = super(reload_assoc)
+            args.empty? ? result : tags_with_type_scoping(tag_type, *args)
+          end
         else # handle the Tagtical::Tag subclasses
           define_method(tag_type.scope_name) do |*args|
             if tags.loaded?


### PR DESCRIPTION
## Summary

- Abandon alias method chain for `define_tag_scope`.
- Fix tag validation to search only for relevant tag types. Before that fix validation could fail if the tags with the same value but different types existed. The fix restricts tag types to only inherited types.